### PR TITLE
Load subr-x for hash-table-keys

### DIFF
--- a/ivy-emms.el
+++ b/ivy-emms.el
@@ -38,6 +38,7 @@
 (require 'emms-source-file)
 (require 'emms-cache)
 (require 'ivy)
+(require 'subr-x)
 
 ;;* User options
 (defgroup ivy-emms nil


### PR DESCRIPTION
Fix following a byte-compile warning

```
In end of data:
ivy-emms.el:165:1:Warning: the function ‘hash-table-keys’ is not known to be
    defined.
```